### PR TITLE
Feature/api login

### DIFF
--- a/hoomi/api/serializers/__init__.py
+++ b/hoomi/api/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .user import UserSerializer

--- a/hoomi/api/serializers/user.py
+++ b/hoomi/api/serializers/user.py
@@ -1,0 +1,23 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework import serializers
+from jobs.models import Job
+
+
+class UserSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+    email = serializers.CharField(write_only=True)
+    name = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = get_user_model()
+
+    def create(self, validated_data):
+
+        user = get_user_model().objects.create_user(
+            email=validated_data.get('email'),
+            name=validated_data.get('name'),
+            password=validated_data.get('password'),
+        )
+
+        return user

--- a/hoomi/api/urls/__init__.py
+++ b/hoomi/api/urls/__init__.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url, include
 
+
 urlpatterns = [
+    url(r'^mobile/', include('api.urls.mobile', namespace="mobile")),
     url(r'^token/', include('api.urls.token', namespace="tokens")),
 ]

--- a/hoomi/api/urls/mobile.py
+++ b/hoomi/api/urls/mobile.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url, include
+
+from rest_framework_jwt.views import obtain_jwt_token
+
+from api.views.mobile import *
+
+urlpatterns = [
+    url(r'^signup/$', UserCreateAPIView.as_view(), name="signup"),
+    url(r'^login/$', obtain_jwt_token, name="login"),
+]

--- a/hoomi/api/urls/token.py
+++ b/hoomi/api/urls/token.py
@@ -1,12 +1,10 @@
 from django.conf.urls import url
 
-from rest_framework_jwt.views import obtain_jwt_token
 from rest_framework_jwt.views import verify_jwt_token
 from rest_framework_jwt.views import refresh_jwt_token
 
 
 urlpatterns = [
-    url(r'^auth/$', obtain_jwt_token),
     url(r'^verify/$', verify_jwt_token),
     url(r'^refresh/$', refresh_jwt_token),
 ]

--- a/hoomi/api/views/mobile/__init__.py
+++ b/hoomi/api/views/mobile/__init__.py
@@ -1,0 +1,1 @@
+from .user import UserCreateAPIView

--- a/hoomi/api/views/mobile/signup.py
+++ b/hoomi/api/views/mobile/signup.py
@@ -1,0 +1,16 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework.generics import CreateAPIView
+from rest_framework_jwt.settings import api_settings
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+
+from api.serializers import UserSerializer
+
+
+class UserCreateAPIView(CreateAPIView):
+    queryset = get_user_model()
+    serializer_class = UserSerializer
+    permission_classes = (AllowAny, )
+    authentication_classes = ()

--- a/hoomi/api/views/mobile/user.py
+++ b/hoomi/api/views/mobile/user.py
@@ -1,0 +1,16 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework.generics import CreateAPIView
+from rest_framework_jwt.settings import api_settings
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+
+from api.serializers import UserSerializer
+
+
+class UserCreateAPIView(CreateAPIView):
+    queryset = get_user_model()
+    serializer_class = UserSerializer
+    permission_classes = (AllowAny, )
+    authentication_classes = ()

--- a/hoomi/users/models/user.py
+++ b/hoomi/users/models/user.py
@@ -15,8 +15,8 @@ class UserManager(BaseUserManager):
 
     def create_superuser(self, email, password, **kwargs):
         user = self.create_user(
-                email=self.normalize_email(email),
-                **kwargs
+            email=self.normalize_email(email),
+            **kwargs
         )
         user.is_admin = True
         user.set_password(password)
@@ -24,7 +24,10 @@ class UserManager(BaseUserManager):
 
 
 class User(AbstractBaseUser, PermissionsMixin):
-    job = models.ForeignKey(Job)
+    job = models.ForeignKey(
+        Job,
+        default=2,
+    )
     name = models.CharField(
             max_length=60,
     )


### PR DESCRIPTION
1. 회원가입
   지금 hoomi 프로젝트의 permission, authentication으로는 회원가입이
   원할하게 안된다.
   
   permission_classes = (AllowAny, )
   authentication_classes = ()
   
   그래서 APIView에서 위와같이 설정을 해주어서 회원가입 하는 API View만
   permission, authentication을 다르게 설정을 해준다.
2. 로그인
   로그인 같은경우에는 기존에 djangorestframework-jwt에서 사용하는
   `obtain_jwt_token`를 사용하여 로그인을 대처한다.
