### PR TITLE
refactor ExperienceDetailListAPIView: remove get_or_none using

### DIFF
--- a/hoomi/api/views/jobs/detail_experience.py
+++ b/hoomi/api/views/jobs/detail_experience.py
@@ -1,6 +1,7 @@
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework import status
+from django.shortcuts import get_object_or_404
 
 from jobs.models import PhotoJobHistory
 from api.paginations.detail import DetailPagination
@@ -14,6 +15,6 @@ class ExperienceDetailListAPIView(ListAPIView):
 
     def get_queryset(self):
         hash_id = self.kwargs.get("hash_id")
-        photo = PhotoJobHistory.objects.get_or_none(hash_id=hash_id)
+        photo = get_object_or_404(PhotoJobHistory, hash_id=hash_id)
 
         return photo.experience_set.all()

--- a/hoomi/jobs/models/photo_job_history.py
+++ b/hoomi/jobs/models/photo_job_history.py
@@ -4,17 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from .abstract_job_history import AbstractJobHistory
 
 
-class PhotoJobManager(models.Manager):
-    def get_or_none(self, hash_id):
-        try:
-            return self.get(hash_id=hash_id)
-        except ObjectDoesNotExist as exc:
-            return None
-
-
 class PhotoJobHistory(AbstractJobHistory):
-
-    objects = PhotoJobManager()
 
     hash_id = models.CharField(
         max_length=5,


### PR DESCRIPTION
get_object_or_404

기존에 manager로 만든 get_or_none를 좀 더 명시적으로 하기 위해
get_object_or_404를 사용
