### PR TITLE
Feature/photo job create api view

### DIFF
--- a/hoomi/api/serializers/jobs/photo_job_history.py
+++ b/hoomi/api/serializers/jobs/photo_job_history.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from django.shortcuts import get_object_or_404
+
 from jobs.models import PhotoJobHistory
 from jobs.models import Experience
 
@@ -12,6 +14,44 @@ class ExperienceSerializer(serializers.ModelSerializer):
             "image",
             "content",
         ]
+
+    def create(self, validated_data):
+        request = self.context.get("request")
+        user = request.user
+        hash_id = request.parser_context.get("kwargs").get("hash_id")
+
+        photo_job = get_object_or_404(
+            user.photojobhistory_set,
+            hash_id=hash_id,
+        )
+
+        # user -> Image Field save required
+        # photo_job -> Experience create ForeignKey required
+        validated_data["user"] = user
+        validated_data["photo_job"] = photo_job
+
+        ModelClass = self.Meta.model
+
+        try:
+            instance = ModelClass.objects.create(**validated_data)
+        except TypeError as exc:
+            msg = (
+                'Got a `TypeError` when calling `%s.objects.create()`. '
+                'This may be because you have a writable field on the '
+                'serializer class that is not a valid argument to '
+                '`%s.objects.create()`. You may need to make the field '
+                'read-only, or override the %s.create() method to handle '
+                'this correctly.\nOriginal exception text was: %s.' %
+                (
+                    ModelClass.__name__,
+                    ModelClass.__name__,
+                    self.__class__.__name__,
+                    exc
+                )
+            )
+            raise TypeError(msg)
+
+        return instance
 
 
 class PhotoJobHistorySerializer(serializers.ModelSerializer):

--- a/hoomi/api/tests/test_modules/test_photojob.py
+++ b/hoomi/api/tests/test_modules/test_photojob.py
@@ -80,10 +80,12 @@ class TestCreatePhotoJob(TestCase):
             content_type="image/png"
         )
 
+        test_content = "test_job_create"
+
         data = {
             "theme": test_theme,
             "image": test_image,
-            "content": "1111",
+            "content": test_content,
         }
 
         response = self.client.post(
@@ -96,6 +98,11 @@ class TestCreatePhotoJob(TestCase):
 
         self.assertEquals(
             201,
+            response.status_code,
+        )
+
+        self.assertEqual(
+            test_content,
             response.status_code,
         )
 
@@ -112,10 +119,10 @@ class TestCreatePhotoJob(TestCase):
 
         hash_id = photo_job.hash_id
 
-        get_url = "/api/job-history/" + hash_id + "/"
+        set_uri = "/api/job-history/" + hash_id + "/"
 
         response = self.client.get(
-            get_url,
+            set_uri,
             data={},
             HTTP_AUTHORIZATION="JWT {token}".format(
                 token=self.token,
@@ -131,7 +138,7 @@ class TestCreatePhotoJob(TestCase):
         photo_job = self.get_photo_job()
         test_theme = 22
 
-        get_url = "/api/job-history/{hash_id}/".format(
+        set_uri = "/api/job-history/{hash_id}/".format(
             hash_id=photo_job.hash_id,
         )
 
@@ -141,7 +148,7 @@ class TestCreatePhotoJob(TestCase):
         }
 
         response = self.client.patch(
-            path=get_url,
+            path=set_uri,
             data=json.dumps(data),
             content_type="application/json",
             HTTP_AUTHORIZATION="JWT {token}".format(
@@ -168,12 +175,12 @@ class TestCreatePhotoJob(TestCase):
     def test_photo_job_delete_should_return_204(self):
         photo_job = self.get_photo_job()
 
-        get_url = "/api/job-history/{hash_id}/".format(
+        set_uri = "/api/job-history/{hash_id}/".format(
             hash_id=photo_job.hash_id,
         )
 
         response = self.client.delete(
-            path=get_url,
+            path=set_uri,
             HTTP_AUTHORIZATION="JWT {token}".format(
                 token=self.token,
             )
@@ -184,29 +191,61 @@ class TestCreatePhotoJob(TestCase):
             response.status_code,
         )
 
+    def test_experience_create_should_return_201(self):
+        photo_job = self.get_photo_job()
+
+        set_uri = "/api/job-history/{hash_id}/".format(
+            hash_id=photo_job.hash_id,
+        )
+
+        image = settings.PROJECT_ROOT_DIR + "/dist/media/test.png"
+        test_content = "test_create"
+
+        test_image = SimpleUploadedFile(
+            name="test.png",
+            content=open(image, "rb").read(),
+            content_type="image/png"
+        )
+
+        data = {
+            "image": test_image,
+            "content": test_content,
+        }
+
+        response = self.client.post(
+            path=set_uri,
+            data=data,
+            HTTP_AUTHORIZATION="JWT {token}".format(
+                token=self.token,
+            )
+        )
+
+        self.assertEqual(
+            201,
+            response.status_code,
+        )
+
+        self.assertEqual(
+            test_content,
+            response.data.get("content"),
+        )
+
     def test_experience_patch_shoud_return_200(self):
         photo_job = self.get_photo_job()
 
-        get_url = "/api/job-history/{hash_id}/{id}/".format(
+        set_uri = "/api/job-history/{hash_id}/{id}/".format(
             hash_id=photo_job.hash_id,
             id=photo_job.experience_set.first().id,
         )
 
-        image = settings.PROJECT_ROOT_DIR + "/dist/media/test2.png"
-        test_content = "test_patch"
-
-        test_image = SimpleUploadedFile(
-            name="test2.png",
-            content=open(image, "rb").read(),
-            content_type="image/png"
-        )
+        test_content = "test_create"
 
         data = {
             "content": test_content,
         }
 
         response = self.client.patch(
-            path=get_url,
+            path=set_uri,
             data=json.dumps(data),
             content_type="application/json",
             HTTP_AUTHORIZATION="JWT {token}".format(
@@ -228,13 +267,13 @@ class TestCreatePhotoJob(TestCase):
         photo_job = self.get_photo_job()
 
         hash_id = photo_job.hash_id
-        get_url = "/api/job-history/{hash_id}/{id}/".format(
+        set_uri = "/api/job-history/{hash_id}/{id}/".format(
             hash_id=photo_job.hash_id,
             id=photo_job.experience_set.first().id,
         )
 
         response = self.client.delete(
-            path=get_url,
+            path=set_uri,
             HTTP_AUTHORIZATION="JWT {token}".format(
                 token=self.token,
             )

--- a/hoomi/api/views/auth/photo_job_mypage.py
+++ b/hoomi/api/views/auth/photo_job_mypage.py
@@ -17,10 +17,10 @@ class PhotoJobMyPageListAPIView(ListAPIView):
 
     def patch(self, request, *args, **kwargs):
         job_id = request.data.get('job')
-        job_title = get_object_or_404(Job, id=job_id)
+        job = get_object_or_404(Job, id=job_id)
 
         user = request.user
-        user.job.title = job_title.title
+        user.job = job
         user.save()
 
         response_data = {

--- a/hoomi/api/views/jobs/detail_experience.py
+++ b/hoomi/api/views/jobs/detail_experience.py
@@ -9,6 +9,7 @@ from api.serializers import ExperienceSerializer
 
 
 class ExperienceDetailListPatchDestroyAPIView(mixins.ListModelMixin,
+                                              mixins.CreateModelMixin,
                                               GenericAPIView):
 
     serializer_class = ExperienceSerializer
@@ -36,6 +37,16 @@ class ExperienceDetailListPatchDestroyAPIView(mixins.ListModelMixin,
         )
 
         return photo_job
+
+    def post(self, request, *args, **kwargs):
+        if not request.FILES:
+            response_data = {"Error": "image required"}
+            return Response(
+                response_data,
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+        return self.create(request, *args, **kwargs)
 
     def patch(self, request, *args, **kwargs):
         photo_job = self.get_photo_job()

--- a/hoomi/api/views/jobs/photo_job_history.py
+++ b/hoomi/api/views/jobs/photo_job_history.py
@@ -29,11 +29,4 @@ class PhotoJobHistoryListCreateAPIView(ListCreateAPIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        self.create(request, *args, **kwargs)
-
-        response_data = {"Success": "Created data"}
-
-        return Response(
-            response_data,
-            status.HTTP_201_CREATED,
-        )
+        return self.create(request, *args, **kwargs)


### PR DESCRIPTION
## CreateModelMixin를 상속받아 사용하기 때문에 Response를 따로 지정해둘 필요가 없어서 삭제

`Response(serializer.data, status=status.HTTP_201_CREATED,headers=headers)`

CreateModelMixin에서 위와 같이 제공
## Experience Create API

Post `/api/job-history/<hash_id>`

Post요청으로 위 uri에 `image`, `content`를 보내면
hash_id에 해당하는 자식 experience를 생성

이미지가 포함되어 있지않으면 `HTTP_400_BAD_REQUEST` response

Success
- `HTTP_201_CREATED` response

Fail
- 해당하는 데이터가 없을시: `HTTP_404_NOT_FOUND` response
## Experience Create Test Code

add experience create test code and refactor uri naming
